### PR TITLE
allow for multiple icons to be placed in article

### DIFF
--- a/_layouts/map.html
+++ b/_layouts/map.html
@@ -64,7 +64,12 @@ counter += 1;
       marker.iconURL = iconurl;
 
       filename = "{{post.url}}"
-      items[filename] = marker;
+      if (items[filename] == undefined) { 
+      items[filename] = [marker];
+      } else {
+      items[filename].push(marker);
+      }
+      
       layers.push(marker);
 
       marker.on('click', function(){
@@ -74,6 +79,7 @@ counter += 1;
         window.location = (post_url);
         articlerender(article_url, item_id);
       });
+      
       {% endfor %}
 
     var imageurl = '<img class="legend" src="' + iconurl + '">'

--- a/js/site.js
+++ b/js/site.js
@@ -17,15 +17,22 @@ function reloadhtml(){
 };
 
 function articlerender(articleurl, item_id){
-    console.log(item_id);
     marker = items[item_id];
-    var articleicon = "<img class='article-marker' src='" + marker.iconURL  + "' onclick='mapClick()'>";
+    if (marker.length > 1 ) {
+    var articleicon = ''
+    for (i = 0; i < marker.length; i++) { 
+    articleicon += "<img class='article-marker' src='" + marker[i].iconURL + "' onclick='mapClick(" + i +")'>";
+    marker[i].openPopup();
+	}
+    } else {
+    var articleicon = "<img class='article-marker' src='" + marker[0].iconURL  + "' onclick='mapClick(0)'>";
+    marker[0].openPopup();
+    }
   	$.get(article_url, function(data){
     	var index = data.indexOf("</h1>");
         data = data.slice(0, index) + articleicon + data.slice(index);
         $("#sidebar-content").html(data);
     });
-   marker.openPopup();
    $( ".sidebar" ).scrollTop(0); //tell sidebar scroll to go to the top
 }
 
@@ -33,7 +40,7 @@ function pagerender(page_url){
 	$.get(page_url, function(data){
 		$("#sidebar-content").html(data);
 	  });
-	this.marker.closePopup();
+	map.closePopup();
 	$( ".sidebar" ).scrollTop(0); //tell sidebar scroll to go to the top
 }
 
@@ -49,10 +56,10 @@ function onClick(url){
 }
 
 
-function mapClick(){
+function mapClick(i){
   url = window.location.href;
   url = url.split("#");
   item_id = url[1];
   marker = items[item_id];
-  marker.togglePopup();
+  marker[i].togglePopup();
 };


### PR DESCRIPTION
View example here: https://dnoneill.github.io/testflaneur/#/article/2017-12-20-f17-10. img.article-marker css might need a little tweaking,  couldn't figure out why images were now inline in certain articles (see https://dnoneill.github.io/testflaneur/#/article/2013-09-01-academyawards). Works for even without css to create greater usability.
  